### PR TITLE
Add stuff from 2025 Live Más Live

### DIFF
--- a/fauxo_bell.json
+++ b/fauxo_bell.json
@@ -52,7 +52,11 @@
     "12 piece ",
     "Famous ",
     "Cheez-it ",
-    "Cheesy Dipping "
+    "Cheesy Dipping ",
+    "Street ",
+    "Flamin' Hot ",
+    "Steak and Queso ",
+    "Quesocrisp "
   ],
   "name": [
     "Burger",
@@ -79,13 +83,16 @@
     "Bucket",
     "Pot Pie",
     "Wrap",
-    "Bowl"
+    "Bowl",
+    "Crunchwrap",
+    "Crunchwrap #modifier#"
   ],
   "modifier": [
     "Bucket",
     "Bowl",
     "BellGrande",
     "Deluxe",
-    "Supreme"
+    "Supreme",
+    "Sliders"
   ]
 }


### PR DESCRIPTION
See https://www.sj-r.com/story/money/food/2025/03/06/taco-bell-new-menu-items-2025/81757302007/ for details.

But also I WAS MISSING CRUNCHWRAP? What the hell?!